### PR TITLE
Support training SNLDS on basketball data (for TMLR rebuttal)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ __pycache__
 data/*.npy
 data/*.npz
 results/*
+
+devel/
+
+data/basketball/
+

--- a/configs/basketball.yaml
+++ b/configs/basketball.yaml
@@ -2,6 +2,7 @@ experiment: basketball
 model: SNLDS #REDSDS
 dataset: basketball
 n_players: 1
+n_train_games_list: [20] # some subset of 1,5,20
 obs_dim: 2 #should be n_players x court_dim = n_players x 2. #TODO: compute this programmatically.
 x_dim: 4 # Double obs_dim might make sense.
 # seg_labels: true
@@ -20,7 +21,7 @@ log_steps: 1000 #2500
 save_steps: 1000 #2500
 num_categories: 10
 warmup_steps_lr: 1000
-num_steps: 30000   # must exceed warmup_steps_lr 
+num_steps: 60000 #30000   # must exceed warmup_steps_lr 
 num_samples: 1 #5 #30
 objective: elbov2
 flat_learning_rate: false

--- a/configs/basketball.yaml
+++ b/configs/basketball.yaml
@@ -9,7 +9,7 @@ batch_size: 32
 context_length: 10000 #not used
 prediction_length: 30
 #freq: H # not used
-x_dim: 30 # 8
+x_dim: 40 
 obs_dim: 20
 model_dir: ./results/basketball/{timestamp}/models/
 train_history_dir: ./results/basketball/{timestamp}/train_history/
@@ -18,13 +18,13 @@ log_dir: ./results/basketball/{timestamp}/logs/
 log_steps: 500
 save_steps: 500
 num_categories: 10
-warmup_steps_lr: 500 #2000
-num_steps: 10000 #20000   # must exceed warmup_steps_lr 
-num_samples: 5 #10 #30
+warmup_steps_lr: 1000
+num_steps: 30000   # must exceed warmup_steps_lr 
+num_samples: 1 #5 #30
 objective: elbov2
 flat_learning_rate: false
-warmup_start_lr: 5.e-3 #5.e-5
-learning_rate: 0.002 #0.0002
+warmup_start_lr: 1.e-4
+learning_rate: 7.e-3
 grad_clip_norm: 10.
 weight_decay: 1.e-5
 initial_switch:
@@ -39,7 +39,7 @@ continuous_transition:
   fixed_sigma: .0003 #0.02
   max_scale: .0003 #0.25
   scale_nonlinearity: softplus
-  mlp_hiddendim: 8
+  mlp_hiddendim: 32
 emission:
   model_type: nonlinear
   tied_cov: true
@@ -53,9 +53,9 @@ inference:
   fixed_sigma: .0003  # 0.02
   max_scale: .0003 #0.25
   scale_nonlinearity: softplus
-  embedder: brnn  # transformer or brnn
+  embedder: transformer #brnn  # transformer or brnn
 # BRNN params
-  embedding_rnndim: 16
+  embedding_rnndim: 4
   embedding_rnnlayers: 1
 # Transformer params
   embedding_trans_usepe: true
@@ -104,8 +104,8 @@ dur_t_annealing_steps: 100
 dur_t_annealing_kickin_steps: 5000
 cont_ent_anneal: 1.0
 # Unused or inconsequential
-xent_annealing: false
-xent_init: 100.
-xent_rate: 0.95
+xent_annealing: true
+xent_init: 0.
+xent_rate: 0.99
 xent_steps: 50
-xent_kickin_steps: 2000
+xent_kickin_steps: 0

--- a/configs/basketball.yaml
+++ b/configs/basketball.yaml
@@ -21,7 +21,7 @@ log_steps: 1000 #2500
 save_steps: 1000 #2500
 num_categories: 10
 warmup_steps_lr: 1000
-num_steps: 60000 #30000   # must exceed warmup_steps_lr 
+num_steps: 75000 #30000   # must exceed warmup_steps_lr 
 num_samples: 1 #5 #30
 objective: elbov2
 flat_learning_rate: false

--- a/configs/basketball.yaml
+++ b/configs/basketball.yaml
@@ -16,8 +16,8 @@ model_dir: ./results/basketball/{timestamp}/models/
 train_history_dir: ./results/basketball/{timestamp}/train_history/
 forecasts_dir: ./results/basketball/{timestamp}/forecasts/
 log_dir: ./results/basketball/{timestamp}/logs/
-log_steps: 2500
-save_steps: 2500
+log_steps: 1000 #2500
+save_steps: 1000 #2500
 num_categories: 10
 warmup_steps_lr: 1000
 num_steps: 30000   # must exceed warmup_steps_lr 

--- a/configs/basketball.yaml
+++ b/configs/basketball.yaml
@@ -1,0 +1,105 @@
+experiment: basketball
+model: SNLDS #R3EDSDS
+dataset: basketball
+# seg_labels: true
+# only_segmentation: True
+d_min: 20 # duration 
+d_max: 50 # duration 
+batch_size: 32
+context_length: 10000 #not used
+prediction_length: 30
+#freq: H # not used
+x_dim: 2 # 8
+obs_dim: 20
+log_dir: ./results/basketball/{timestamp}/logs/
+log_steps: 500
+model_dir: ./results/basketball/{timestamp}/models/
+save_steps: 500
+num_categories: 3
+num_steps: 10000 #20000
+num_samples: 1
+objective: elbov2
+flat_learning_rate: false
+warmup_start_lr: 5.e-5
+learning_rate: 0.0002
+grad_clip_norm: 10.
+weight_decay: 1.e-5
+warmup_steps_lr: 2000
+initial_switch:
+  mlp_hiddendim: 8
+discrete_transition:
+  takes_x: true
+  takes_y: true
+continuous_transition:
+  model_type: linear
+  tied_cov: false
+  trainable_cov: true
+  fixed_sigma: .0003 #0.02
+  max_scale: .0003 #0.25
+  mlp_hiddendim: 8
+emission:
+  model_type: linear
+  tied_cov: true
+  trainable_cov: true
+  fixed_sigma:  0.003 #0.02
+  max_scale: 0.003 #0.25
+inference: 
+  tied_cov: false
+  trainable_cov: true
+  fixed_sigma: .0003  # 0.02
+  max_scale: .0003 #0.25
+  embedder: brnn  # transformer or brnn
+# BRNN params
+  embedding_rnndim: 16
+  embedding_rnnlayers: 1
+# Transformer params
+  embedding_trans_usepe: true
+  embedding_trans_nhead: 1
+  embedding_trans_embdim: 4
+  embedding_trans_mlpdim: 16
+  embedding_trans_nlayers: 1
+# Causal RNN
+  use_causal_rnn: true
+  causal_rnndim: 16
+# MLP
+  mlp_hiddendim: 32
+initial_state:
+  tied_cov: true
+  trainable_cov: true
+  fixed_sigma: 0.02
+  max_scale: 0.25
+  mlp_hiddendim: 8
+control:
+  mlp_hiddendim: 64
+  has_ctrl: false
+  z: false
+  x: false
+  inference: false
+  emb_dim: 0
+  feat_dim: 0
+  n_staticfeat: 0
+  n_timefeat: 0
+transform_target: false
+transform_only_scale: false
+use_jacobian: false
+forecast:
+  num_samples: 20
+switch_t_annealing: true
+switch_t_init: 100.
+switch_t_min: 10.
+switch_t_annealing_rate: 0.95
+switch_t_annealing_steps: 100
+switch_t_annealing_kickin_steps: 5000
+dur_t_annealing: true
+dur_t_init: 10.
+dur_t_min: 1.
+dur_t_annealing_rate: 0.95
+dur_t_annealing_steps: 100
+dur_t_annealing_kickin_steps: 5000
+cont_ent_anneal: 1.0
+# Unused or inconsequential
+xent_annealing: false
+xent_init: 100.
+xent_rate: 0.95
+xent_steps: 50
+xent_kickin_steps: 2000

--- a/configs/basketball.yaml
+++ b/configs/basketball.yaml
@@ -1,7 +1,10 @@
 experiment: basketball
 model: SNLDS #REDSDS
 dataset: basketball
-n_players: 1 
+n_train_games: 1
+n_players: 1
+obs_dim: 2 #should be n_players x court_dim = n_players x 2. #TODO: compute this programmatically.
+x_dim: 4 # Double obs_dim might make sense.
 # seg_labels: true
 # only_segmentation: True
 d_min: 20 # duration 
@@ -10,8 +13,6 @@ batch_size: 32
 context_length: 10000 #not used
 prediction_length: 30
 #freq: H # not used
-x_dim: 40 
-obs_dim: 20
 model_dir: ./results/basketball/{timestamp}/models/
 train_history_dir: ./results/basketball/{timestamp}/train_history/
 forecasts_dir: ./results/basketball/{timestamp}/forecasts/

--- a/configs/basketball.yaml
+++ b/configs/basketball.yaml
@@ -1,7 +1,6 @@
 experiment: basketball
 model: SNLDS #REDSDS
 dataset: basketball
-n_train_games: 1
 n_players: 1
 obs_dim: 2 #should be n_players x court_dim = n_players x 2. #TODO: compute this programmatically.
 x_dim: 4 # Double obs_dim might make sense.
@@ -17,8 +16,8 @@ model_dir: ./results/basketball/{timestamp}/models/
 train_history_dir: ./results/basketball/{timestamp}/train_history/
 forecasts_dir: ./results/basketball/{timestamp}/forecasts/
 log_dir: ./results/basketball/{timestamp}/logs/
-log_steps: 500
-save_steps: 500
+log_steps: 2500
+save_steps: 2500
 num_categories: 10
 warmup_steps_lr: 1000
 num_steps: 30000   # must exceed warmup_steps_lr 

--- a/configs/basketball.yaml
+++ b/configs/basketball.yaml
@@ -2,7 +2,7 @@ experiment: basketball
 model: SNLDS #REDSDS
 dataset: basketball
 n_players: 1
-n_train_games_list: [20] # some subset of 1,5,20
+n_train_games_list: [20,5,1] # some subset of 1,5,20
 obs_dim: 2 #should be n_players x court_dim = n_players x 2. #TODO: compute this programmatically.
 x_dim: 4 # Double obs_dim might make sense.
 # seg_labels: true
@@ -21,7 +21,7 @@ log_steps: 1000 #2500
 save_steps: 1000 #2500
 num_categories: 10
 warmup_steps_lr: 1000
-num_steps: 75000 #30000   # must exceed warmup_steps_lr 
+num_steps: 20000   # must exceed warmup_steps_lr 
 num_samples: 1 #5 #30
 objective: elbov2
 flat_learning_rate: false

--- a/configs/basketball.yaml
+++ b/configs/basketball.yaml
@@ -1,6 +1,7 @@
 experiment: basketball
 model: SNLDS #REDSDS
 dataset: basketball
+n_players: 1 
 # seg_labels: true
 # only_segmentation: True
 d_min: 20 # duration 

--- a/configs/basketball.yaml
+++ b/configs/basketball.yaml
@@ -1,5 +1,5 @@
 experiment: basketball
-model: SNLDS #R3EDSDS
+model: SNLDS #REDSDS
 dataset: basketball
 # seg_labels: true
 # only_segmentation: True
@@ -9,45 +9,50 @@ batch_size: 32
 context_length: 10000 #not used
 prediction_length: 30
 #freq: H # not used
-x_dim: 2 # 8
+x_dim: 30 # 8
 obs_dim: 20
+model_dir: ./results/basketball/{timestamp}/models/
+train_history_dir: ./results/basketball/{timestamp}/train_history/
+forecasts_dir: ./results/basketball/{timestamp}/forecasts/
 log_dir: ./results/basketball/{timestamp}/logs/
 log_steps: 500
-model_dir: ./results/basketball/{timestamp}/models/
 save_steps: 500
-num_categories: 3
-num_steps: 10000 #20000
-num_samples: 1
+num_categories: 10
+warmup_steps_lr: 500 #2000
+num_steps: 10000 #20000   # must exceed warmup_steps_lr 
+num_samples: 5 #10 #30
 objective: elbov2
 flat_learning_rate: false
-warmup_start_lr: 5.e-5
-learning_rate: 0.0002
+warmup_start_lr: 5.e-3 #5.e-5
+learning_rate: 0.002 #0.0002
 grad_clip_norm: 10.
 weight_decay: 1.e-5
-warmup_steps_lr: 2000
 initial_switch:
   mlp_hiddendim: 8
 discrete_transition:
   takes_x: true
   takes_y: true
 continuous_transition:
-  model_type: linear
+  model_type: nonlinear
   tied_cov: false
   trainable_cov: true
   fixed_sigma: .0003 #0.02
   max_scale: .0003 #0.25
+  scale_nonlinearity: softplus
   mlp_hiddendim: 8
 emission:
-  model_type: linear
+  model_type: nonlinear
   tied_cov: true
   trainable_cov: true
-  fixed_sigma:  0.003 #0.02
-  max_scale: 0.003 #0.25
+  fixed_sigma: 0.003 #0.02
+  max_scale:  0.003 #0.25
+  scale_nonlinearity: softplus
 inference: 
   tied_cov: false
   trainable_cov: true
   fixed_sigma: .0003  # 0.02
   max_scale: .0003 #0.25
+  scale_nonlinearity: softplus
   embedder: brnn  # transformer or brnn
 # BRNN params
   embedding_rnndim: 16
@@ -68,6 +73,7 @@ initial_state:
   trainable_cov: true
   fixed_sigma: 0.02
   max_scale: 0.25
+  scale_nonlinearity: softplus
   mlp_hiddendim: 8
 control:
   mlp_hiddendim: 64
@@ -79,7 +85,7 @@ control:
   feat_dim: 0
   n_staticfeat: 0
   n_timefeat: 0
-transform_target: false
+transform_target: false 
 transform_only_scale: false
 use_jacobian: false
 forecast:

--- a/run_basketball.py
+++ b/run_basketball.py
@@ -183,7 +183,7 @@ if __name__ == "__main__":
         raise NotImplementedError(f"This loop now assumes we're running models for one player at a time. "
                                   f"Also the forecasting method with n=10 players seems to be broken. ")
 
-    for n_train_games in [1,5,20]:
+    for n_train_games in config["n_train_games_list"]:
         # TODO: put this back in the correct order.
         for player_idx in [0,1,2,3,4,5,6,7,8,9]:
         

--- a/run_basketball.py
+++ b/run_basketball.py
@@ -214,14 +214,13 @@ if __name__ == "__main__":
                 loss_history_path=os.path.join(config["log_dir"], f"loss_history_{step}.npy")
                 np.save(loss_history_path, loss_history)
             
-                # Make plot of cumulative loss and save to disk.
-                loss__cumulative_mean = np.cumsum(loss_history) / np.arange(1, len(loss_history) + 1)
-                plt.plot(loss__cumulative_mean[:step])
+                # Make plot of loss and save to disk.
+                plt.plot(loss_history-min(loss_history))
                 plt.yscale('log')  # log scale for y-axis
                 plt.xlabel("Step")
-                plt.ylabel("Cumulative Mean (log scale)")
-                loss__cumulative_mean_path=os.path.join(config["log_dir"], f"loss__cumulative_mean_{step}.pdf")
-                plt.savefig(loss__cumulative_mean_path)
+                plt.ylabel("Log (loss - min loss)")
+                loss_plot_path=os.path.join(config["log_dir"], f"loss_history_{step}.pdf")
+                plt.savefig(loss_plot_path)
                 plt.close("all")
 
                 # Save test set forecasts 
@@ -253,14 +252,13 @@ if __name__ == "__main__":
     loss_history_path=os.path.join(config["train_history_dir"], f"loss_history_{step}.npy")
     np.save(loss_history_path, loss_history)
   
-    # Make plot of cumulative loss and save to disk.
-    loss__cumulative_mean = np.cumsum(loss_history) / np.arange(1, len(loss_history) + 1)
-    plt.plot(loss__cumulative_mean)
+    # Make plot of loss and save to disk.
+    plt.plot(loss_history-min(loss_history))
     plt.yscale('log')  # log scale for y-axis
     plt.xlabel("Step")
-    plt.ylabel("Cumulative Mean (log scale)")
-    loss__cumulative_mean_path=os.path.join(config["train_history_dir"], f"loss__cumulative_mean_{step}.pdf")
-    plt.savefig(loss__cumulative_mean_path)
+    plt.ylabel("Log (loss - min loss)")
+    loss_plot_path=os.path.join(config["train_history_dir"], f"loss_history_{step}.pdf")
+    plt.savefig(loss_plot_path)
     plt.close("all")
 
     # To see the plot:

--- a/run_basketball.py
+++ b/run_basketball.py
@@ -17,7 +17,8 @@ from src.basketball.dataset import (
     make_basketball_dataset_test__as_list,
 )
 
-debug_mode = False 
+debug_mode_for_training = False 
+debug_mode_for_forecasting = True 
 verbose_logging = True 
 N_TRAIN_GAMES = 1 
 
@@ -78,7 +79,7 @@ def make_test_forecasts(config, model, device):
     test_forecasts = np.zeros((E, S, T_pred, J, D ))
 
     # Get the preset 78 examples test set examples with hardcoded start/stop indices.    
-    test_dataset__list = make_basketball_dataset_test__as_list() 
+    test_dataset__list = make_basketball_dataset_test__as_list(n_players=config["n_players"]) 
     for e, test_example in enumerate(test_dataset__list):
         test_example = test_example.to(device)
         result_dict = model.predict(
@@ -133,7 +134,7 @@ if __name__ == "__main__":
     # DATA
     # TODO: Add other training lengths besides one game
     # TODO: make traj_length a parameter... Did we use this in other places?
-    train_dataset = make_basketball_dataset_train(data_type=f"train_{N_TRAIN_GAMES}", traj_length=30) 
+    train_dataset = make_basketball_dataset_train(data_type=f"train_{N_TRAIN_GAMES}", traj_length=30, n_players=config["n_players"]) 
     # TODO: check if we can run basketball with more workers.
     num_workers = 0 
     train_loader = torch.utils.data.DataLoader(
@@ -205,9 +206,12 @@ if __name__ == "__main__":
             }
 
             # sanity check for training
-            if debug_mode:
+            if debug_mode_for_training:
                 train_step(train_batch_fixed, model, optimizer, step, config, force_breakpoint=True)
             # see devel_check_reconstruct.py when force_breakpoint=True above.
+
+            if debug_mode_for_forecasting:
+                test_forecasts=make_test_forecasts(config, model, device)
 
             if verbose_logging:
                 # Save loss history (negative ELBO)

--- a/run_basketball.py
+++ b/run_basketball.py
@@ -17,10 +17,10 @@ from src.basketball.dataset import (
     make_basketball_dataset_test__as_list,
 )
 
-debug_mode_for_training = False 
-debug_mode_for_forecasting = True 
+debug_mode_for_training = False
+debug_mode_for_forecasting = False 
 verbose_logging = True 
-N_TRAIN_GAMES = 1 
+
 
 
 def train_step(batch, model, optimizer, step, config, force_breakpoint=False):
@@ -71,15 +71,16 @@ def train_step(batch, model, optimizer, step, config, force_breakpoint=False):
     result["xent_coeff"] = xent_coeff
     return result
 
-def make_test_forecasts(config, model, device):
+def make_test_forecasts(config, model, device, n_players, player_idx):
     # setup format for return value
-    E,J,D = 78,10,2
+    E,D = 78,2
+    J = n_players
     S = config["forecast"]["num_samples"]
     T_pred =config["prediction_length"]
     test_forecasts = np.zeros((E, S, T_pred, J, D ))
 
     # Get the preset 78 examples test set examples with hardcoded start/stop indices.    
-    test_dataset__list = make_basketball_dataset_test__as_list(n_players=config["n_players"]) 
+    test_dataset__list = make_basketball_dataset_test__as_list(n_players=config["n_players"], player_idx=player_idx) 
     for e, test_example in enumerate(test_dataset__list):
         test_example = test_example.to(device)
         result_dict = model.predict(
@@ -93,7 +94,9 @@ def make_test_forecasts(config, model, device):
         # here we reshape the array.  in the return value
         # one example has dimension (S, batch_dim=1, T_pred, JXD).
         # as implied by the init above, we want the whole thing to be (E, S, T_pred, J, D ).
-        test_forecasts[e] =result_dict["forecast"][:,0].reshape(S,  T_pred, J,D )
+        # test_forecasts__reversed =result_dict["forecast"][:,0].reshape(S,  T_pred, J,D )
+        # test_forecasts[e]=test_forecasts__reversed[:,torch.arange(T_pred - 1, -1, -1),:,:]
+        test_forecasts[e]=result_dict["forecast"][:,0].reshape(S,  T_pred, J,D )
     return test_forecasts
 
 
@@ -131,153 +134,140 @@ if __name__ == "__main__":
     with open(os.path.join(config["log_dir"], "config.json"), "w") as fp:
         json.dump(config, fp)
 
-    # DATA
-    # TODO: Add other training lengths besides one game
-    # TODO: make traj_length a parameter... Did we use this in other places?
-    train_dataset = make_basketball_dataset_train(data_type=f"train_{N_TRAIN_GAMES}", traj_length=30, n_players=config["n_players"]) 
-    # TODO: check if we can run basketball with more workers.
-    num_workers = 0 
-    train_loader = torch.utils.data.DataLoader(
-        train_dataset,
-        batch_size=config["batch_size"],
-        num_workers=num_workers,
-        shuffle=True,
-        pin_memory=True,
-    )
+    if config["n_players"]!=1:
+        raise NotImplementedError(f"This loop now assumes we're running models for one player at a time. "
+                                  f"Also the forecasting method with n=10 players seems to be broken. ")
+
+    # TODO: put this back in the correct order.
+    for player_idx in [0,1,2,3,4,5,6,7,8,9]:
+       
+        # TODO: make traj_length a parameter... Did we use this in other places?
+        train_dataset = make_basketball_dataset_train(n_train_games=config["n_train_games"], traj_length=30, n_players=config["n_players"], player_idx=player_idx) 
+        # TODO: check if we can run basketball with more workers.
+        num_workers = 0 
+        train_loader = torch.utils.data.DataLoader(
+            train_dataset,
+            batch_size=config["batch_size"],
+            num_workers=num_workers,
+            shuffle=True,
+            pin_memory=True,
+        )
+
+        train_gen = iter(train_loader)
+
+        print(f'Running {config["model"]} on {config["dataset"]}.')
+        print(f"Train size: {len(train_dataset)}.")
+
+        # MODEL
+        model = build_model(config=config)
+        start_step = 1
+        if args.ckpt:
+            model.load_state_dict(ckpt["model"])
+            start_step = ckpt["step"] + 1
+        model = model.to(device)
+
+        for n, p in model.named_parameters():
+            print(n, p.size())
+
+        # TRAIN
+        optimizer = torch.optim.Adam(
+            model.parameters(), weight_decay=config["weight_decay"]
+        )
+        if args.ckpt:
+            optimizer.load_state_dict(ckpt["optimizer"])
+        summary = SummaryWriter(logdir=config["log_dir"])
+
+        n_steps=(config["num_steps"] + 1)-start_step
+        loss_history = np.zeros(n_steps)
+
+        for s,step in enumerate(range(start_step, config["num_steps"] + 1)):
+            try:
+                train_batch  = next(train_gen)
+                train_batch = train_batch.to(device)
+            except StopIteration:
+                train_gen = iter(train_loader)
+            train_result = train_step(train_batch, model, optimizer, step, config)
+
+            if step==start_step:
+                train_batch_fixed=train_batch
+            if step % config["save_steps"] == 0 or step == config["num_steps"]:
+                model_path = os.path.join(config["model_dir"], f"model_player_{player_idx}_step_{step}.pt")
+                torch.save(
+                    {
+                        "step": step,
+                        "model": model.state_dict(),
+                        "optimizer": optimizer.state_dict(),
+                        "config": config,
+                    },
+                    model_path,
+                )
+
+            if step % config["log_steps"] == 0 or step == config["num_steps"]:
+                summary_items = {
+                    "params/learning_rate": train_result["lr"],
+                    "params/switch_temperature": train_result["switch_temperature"],
+                    "params/dur_temperature": train_result["dur_temperature"],
+                    "params/cross_entropy_coef": train_result["xent_coeff"],
+                    "elbo/training": train_result[config["objective"]],
+                    "xent/training": train_result["crossent_regularizer"],
+                }
+
+                # sanity check for training
+                if debug_mode_for_training:
+                    train_step(train_batch_fixed, model, optimizer, step, config, force_breakpoint=True)
+                    breakpoint()
+                    # see devel_check_reconstruct.py when force_breakpoint=True above.
+
+                if debug_mode_for_forecasting:
+                    test_forecasts=make_test_forecasts(config, model, device, n_players=config["n_players"], player_idx=player_idx)
+                    breakpoint()
+                    # see devel_check_forecasts__one_player.py if we have one player.
+
+                if verbose_logging:
+                    # Save loss history (negative ELBO)
+                    loss_history_path=os.path.join(config["log_dir"], f"loss_history__player_{player_idx}__step_{step}.npy")
+                    np.save(loss_history_path, loss_history)
+                
+                    # Make plot of loss and save to disk.
+                    plt.plot((loss_history-min(loss_history))[:step])
+                    plt.yscale('log')  # log scale for y-axis
+                    plt.xlabel("Step")
+                    plt.ylabel("Log (loss - min loss)")
+                    loss_plot_path=os.path.join(config["log_dir"], f"loss_history__player_{player_idx}__step_{step}.pdf")
+                    plt.savefig(loss_plot_path)
+                    plt.close("all")
+
+                    # Save test set forecasts 
+                    model_name=config["model"]
+                    n_train_games=config["n_train_games"]
+                    forecasts_path=os.path.join(config["log_dir"], f"forecasts_test__{model_name}__n_train_{n_train_games}__step_{step}_player_{player_idx}.npy")
+                    test_forecasts=make_test_forecasts(config, model, device, n_players=config["n_players"], player_idx=player_idx)
+                    np.save(forecasts_path, test_forecasts)
+
+        # Save loss history (negative ELBO)
+        loss_history_path=os.path.join(config["train_history_dir"], f"loss_history__player_{player_idx}__step_{step}.npy")
+        np.save(loss_history_path, loss_history)
+    
+        # Make plot of loss and save to disk.
+        plt.plot(loss_history-min(loss_history))
+        plt.yscale('log')  # log scale for y-axis
+        plt.xlabel("Step")
+        plt.ylabel("Log (loss - min loss)")
+        loss_plot_path=os.path.join(config["train_history_dir"], f"loss_history__player_{player_idx}__step_{step}.pdf")
+        plt.savefig(loss_plot_path)
+        plt.close("all")
+
+        # To see the plot:
+        #import matplotlib
+        #matplotlib.use("Qt5Agg") 
+        #plt.show()
 
 
-    train_gen = iter(train_loader)
-
-    print(f'Running {config["model"]} on {config["dataset"]}.')
-    print(f"Train size: {len(train_dataset)}.")
-
-    # MODEL
-    model = build_model(config=config)
-    start_step = 1
-    if args.ckpt:
-        model.load_state_dict(ckpt["model"])
-        start_step = ckpt["step"] + 1
-    model = model.to(device)
-
-    for n, p in model.named_parameters():
-        print(n, p.size())
-
-    # TRAIN
-    optimizer = torch.optim.Adam(
-        model.parameters(), weight_decay=config["weight_decay"]
-    )
-    if args.ckpt:
-        optimizer.load_state_dict(ckpt["optimizer"])
-    summary = SummaryWriter(logdir=config["log_dir"])
-
-    n_steps=(config["num_steps"] + 1)-start_step
-    loss_history = np.zeros(n_steps)
-
-    for s,step in enumerate(range(start_step, config["num_steps"] + 1)):
-        try:
-            train_batch  = next(train_gen)
-            train_batch = train_batch.to(device)
-        except StopIteration:
-            train_gen = iter(train_loader)
-        train_result = train_step(train_batch, model, optimizer, step, config)
-
-        if step==start_step:
-            train_batch_fixed=train_batch
-        if step % config["save_steps"] == 0 or step == config["num_steps"]:
-            model_path = os.path.join(config["model_dir"], f"model_{step}.pt")
-            torch.save(
-                {
-                    "step": step,
-                    "model": model.state_dict(),
-                    "optimizer": optimizer.state_dict(),
-                    "config": config,
-                },
-                model_path,
-            )
-
-        if step % config["log_steps"] == 0 or step == config["num_steps"]:
-            summary_items = {
-                "params/learning_rate": train_result["lr"],
-                "params/switch_temperature": train_result["switch_temperature"],
-                "params/dur_temperature": train_result["dur_temperature"],
-                "params/cross_entropy_coef": train_result["xent_coeff"],
-                "elbo/training": train_result[config["objective"]],
-                "xent/training": train_result["crossent_regularizer"],
-            }
-
-            # sanity check for training
-            if debug_mode_for_training:
-                train_step(train_batch_fixed, model, optimizer, step, config, force_breakpoint=True)
-            # see devel_check_reconstruct.py when force_breakpoint=True above.
-
-            if debug_mode_for_forecasting:
-                test_forecasts=make_test_forecasts(config, model, device)
-
-            if verbose_logging:
-                # Save loss history (negative ELBO)
-                loss_history_path=os.path.join(config["log_dir"], f"loss_history_{step}.npy")
-                np.save(loss_history_path, loss_history)
-            
-                # Make plot of loss and save to disk.
-                plt.plot((loss_history-min(loss_history))[:step])
-                plt.yscale('log')  # log scale for y-axis
-                plt.xlabel("Step")
-                plt.ylabel("Log (loss - min loss)")
-                loss_plot_path=os.path.join(config["log_dir"], f"loss_history_{step}.pdf")
-                plt.savefig(loss_plot_path)
-                plt.close("all")
-
-                # Save test set forecasts 
-                model_name=config["model"]
-                forecasts_path=os.path.join(config["log_dir"], f"forecasts_test__{model_name}__n_train_{N_TRAIN_GAMES}_{step}.npy")
-                test_forecasts=make_test_forecasts(config, model, device)
-                np.save(forecasts_path, test_forecasts)
-
-            # # sanity check for "forecasting"
-            # result_dict = model.predict(
-            #     train_batch_fixed[0,:,:][None,:,:].to(device),
-            #     num_samples=config["forecast"]["num_samples"],
-            #     basketball=True,
-            # )
-            # S = config["forecast"]["num_samples"]
-            # T_pred =config["prediction_length"]
-            # J,D = 10,2 
-            # forecast=result_dict["forecast"][:,0].reshape(S,  T_pred, J,D )
-            # breakpoint()
-        # Rk: I don't think we have any use for result_dict["z_emp_probs"]?
-        #       This seems to be the z probs in the forecast range.
-
-        # here we reshape the array.  in the return value
-        # one example has dimension (S, batch_dim=1, T_pred, JXD).
-        # as implied by the init above, we want the whole thing to be (E, S, T_pred, J, D ).
-  
-
-    # Save loss history (negative ELBO)
-    loss_history_path=os.path.join(config["train_history_dir"], f"loss_history_{step}.npy")
-    np.save(loss_history_path, loss_history)
-  
-    # Make plot of loss and save to disk.
-    plt.plot(loss_history-min(loss_history))
-    plt.yscale('log')  # log scale for y-axis
-    plt.xlabel("Step")
-    plt.ylabel("Log (loss - min loss)")
-    loss_plot_path=os.path.join(config["train_history_dir"], f"loss_history_{step}.pdf")
-    plt.savefig(loss_plot_path)
-    plt.close("all")
-
-    # To see the plot:
-    #import matplotlib
-    #matplotlib.use("Qt5Agg") 
-    #plt.show()
-
-
-    # Make and save test set forecasts 
-    test_forecasts=make_test_forecasts(config, model, device)
-    model_name=config["model"]
-    forecasts_path=os.path.join(config["forecasts_dir"], f"forecasts_test__{model_name}__n_train_{N_TRAIN_GAMES}_{step}.npy")
-    np.save(forecasts_path, test_forecasts)
-
-    breakpoint()
+        # Make and save test set forecasts 
+        test_forecasts=make_test_forecasts(config, model, device, n_players=config["n_players"], player_idx=player_idx)
+        model_name=config["model"]
+        forecasts_path=os.path.join(config["forecasts_dir"], f"forecasts_test__{model_name}__n_train_{n_train_games}__step_{step}__player_{player_idx}.npy")
+        np.save(forecasts_path, test_forecasts)
 
 
 

--- a/run_basketball.py
+++ b/run_basketball.py
@@ -1,0 +1,316 @@
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+import os
+import json
+import torch
+import torch.nn as nn
+import argparse
+import numpy as np
+import matplotlib
+from tensorboardX import SummaryWriter
+import src.utils as utils
+from src.model_utils import build_model
+
+from src.basketball.dataset import (
+    make_basketball_dataset_train, 
+    make_basketball_dataset_test__as_list,
+)
+
+available_datasets = {"basketball"}
+
+
+def train_step(batch, model, optimizer, step, config):
+    model.train()
+
+    def _set_lr(lr):
+        for g in optimizer.param_groups:
+            g["lr"] = lr
+
+    switch_temp = utils.get_temperature(step, config, "switch_")
+    extra_args = dict()
+    dur_temp = 1.0
+    if config["model"] == "REDSDS":
+        dur_temp = utils.get_temperature(step, config, "dur_")
+        extra_args = {"dur_temperature": dur_temp}
+    lr = utils.get_learning_rate(step, config)
+    xent_coeff = utils.get_cross_entropy_coef(step, config)
+    cont_ent_anneal = config["cont_ent_anneal"]
+    optimizer.zero_grad()
+    result = model(
+        batch,
+        switch_temperature=switch_temp,
+        num_samples=config["num_samples"],
+        cont_ent_anneal=cont_ent_anneal,
+        **extra_args,
+    )
+    objective = -1 * (
+        result[config["objective"]] + xent_coeff * result["crossent_regularizer"]
+    )
+    print(
+        step,
+        f"obj: {objective.item():.4f}",
+        f"lr: {lr:.6f}",
+        f"s-temp: {switch_temp:.2f}",
+        f"cross-ent: {xent_coeff}",
+        f"cont ent: {cont_ent_anneal}",
+    )
+    objective.backward()
+    nn.utils.clip_grad_norm_(model.parameters(), config["grad_clip_norm"])
+    _set_lr(lr)
+    optimizer.step()
+    result["objective"] = objective
+    result["lr"] = lr
+    result["switch_temperature"] = switch_temp
+    result["dur_temperature"] = dur_temp
+    result["xent_coeff"] = xent_coeff
+    return result
+
+
+# def plot_results(result, prefix=""):
+#     original_inputs = torch2numpy(result["inputs"][0])
+#     reconstructed_inputs = torch2numpy(result["reconstructions"][0])
+#     most_likely_states = torch2numpy(torch.argmax(result["log_gamma"], dim=-1)[0][0])
+#     hidden_states = torch2numpy(result["x_samples"][0])
+#     discrete_states_lk = torch2numpy(torch.exp(result["log_gamma"][0])[0])
+#     true_seg = None
+#     if "true_seg" in result:
+#         true_seg = torch2numpy(result["true_seg"][0, : config["context_length"]])
+
+#     ylim = 1.3 * np.abs(original_inputs).max()
+#     matplotlib_fig = tensorboard_utils.show_time_series(
+#         fig_size=(12, 4),
+#         inputs=original_inputs,
+#         reconstructed_inputs=reconstructed_inputs,
+#         segmentation=most_likely_states,
+#         true_segmentation=true_seg,
+#         fig_title="input_reconstruction",
+#         ylim=(-ylim, ylim),
+#     )
+#     fig_numpy_array = tensorboard_utils.plot_to_image(matplotlib_fig)
+#     summary.add_image(
+#         f"{prefix}Reconstruction", fig_numpy_array, step, dataformats="HWC"
+#     )
+
+#     matplotlib_fig = tensorboard_utils.show_hidden_states(
+#         fig_size=(12, 3), zt=hidden_states, segmentation=most_likely_states
+#     )
+#     fig_numpy_array = tensorboard_utils.plot_to_image(matplotlib_fig)
+#     summary.add_image(
+#         f"{prefix}Hidden_State_xt", fig_numpy_array, step, dataformats="HWC"
+#     )
+
+#     matplotlib_fig = tensorboard_utils.show_discrete_states(
+#         fig_size=(12, 3),
+#         discrete_states_lk=discrete_states_lk,
+#         segmentation=most_likely_states,
+#     )
+#     fig_numpy_array = tensorboard_utils.plot_to_image(matplotlib_fig)
+#     summary.add_image(
+#         f"{prefix}Discrete_State_zt", fig_numpy_array, step, dataformats="HWC"
+#     )
+
+
+
+if __name__ == "__main__":
+    matplotlib.use("Agg")
+
+    # COMMAND-LINE ARGS
+    parser = argparse.ArgumentParser()
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--config", type=str, help="Path to config file.")
+    group.add_argument("--ckpt", type=str, help="Path to checkpoint file.")
+    parser.add_argument(
+        "--device",
+        type=str,
+        default="cpu",
+        help="Which device to use, e.g., cpu, cuda:0, cuda:1, ...",
+    )
+    
+    # Actual CLI input
+    # args = parser.parse_args()
+
+    # Simulate CLI input
+    args = parser.parse_args(["--config", "configs/basketball.yaml", "--device", "cpu"])
+    #args = parser.parse_args(["--config", "configs/bee_duration.yaml", "--device", "cpu"])
+
+
+    # Inspect
+    print(args)
+
+    # CONFIG
+    if args.ckpt:
+        ckpt = torch.load(args.ckpt, map_location="cpu")
+        config = ckpt["config"]
+    else:
+        config = utils.get_config_and_setup_dirs(args.config)
+    device = torch.device(args.device)
+    with open(os.path.join(config["log_dir"], "config.json"), "w") as fp:
+        json.dump(config, fp)
+
+    # DATA
+    # TODO: Add other training lengths besides one game
+    # TODO: make traj_length a parameter... Did we use this in other places?
+    train_dataset = make_basketball_dataset_train(data_type="train_1", traj_length=30) 
+    # TODO: check if we can run basketball with more workers.
+    num_workers = 0 
+    train_loader = torch.utils.data.DataLoader(
+        train_dataset,
+        batch_size=config["batch_size"],
+        num_workers=num_workers,
+        shuffle=True,
+        pin_memory=True,
+    )
+
+
+    train_gen = iter(train_loader)
+
+    print(f'Running {config["model"]} on {config["dataset"]}.')
+    print(f"Train size: {len(train_dataset)}.")
+
+    # MODEL
+    model = build_model(config=config)
+    start_step = 1
+    if args.ckpt:
+        model.load_state_dict(ckpt["model"])
+        start_step = ckpt["step"] + 1
+    model = model.to(device)
+
+    for n, p in model.named_parameters():
+        print(n, p.size())
+
+    # TRAIN
+    optimizer = torch.optim.Adam(
+        model.parameters(), weight_decay=config["weight_decay"]
+    )
+    if args.ckpt:
+        optimizer.load_state_dict(ckpt["optimizer"])
+    summary = SummaryWriter(logdir=config["log_dir"])
+
+    for step in range(start_step, config["num_steps"] + 1):
+        try:
+            train_batch  = next(train_gen)
+            train_batch = train_batch.to(device)
+        except StopIteration:
+            train_gen = iter(train_loader)
+        train_result = train_step(train_batch, model, optimizer, step, config)
+
+        if step % config["save_steps"] == 0 or step == config["num_steps"]:
+            model_path = os.path.join(config["model_dir"], f"model_{step}.pt")
+            torch.save(
+                {
+                    "step": step,
+                    "model": model.state_dict(),
+                    "optimizer": optimizer.state_dict(),
+                    "config": config,
+                },
+                model_path,
+            )
+
+        if step % config["log_steps"] == 0 or step == config["num_steps"]:
+            summary_items = {
+                "params/learning_rate": train_result["lr"],
+                "params/switch_temperature": train_result["switch_temperature"],
+                "params/dur_temperature": train_result["dur_temperature"],
+                "params/cross_entropy_coef": train_result["xent_coeff"],
+                "elbo/training": train_result[config["objective"]],
+                "xent/training": train_result["crossent_regularizer"],
+            }
+            #train_result["true_seg"] = train_label
+            #plot_results(train_result)
+
+            # # Plot duration models
+            # if config["model"] == "REDSDS":
+            #     dummy_ctrls = torch.ones(1, 1, 1, device=device)
+            #     rho = torch2numpy(
+            #         model.ctrl2nstf_network.rho(
+            #             dummy_ctrls, temperature=train_result["dur_temperature"]
+            #         )
+            #     )[0, 0]
+            #     matplotlib_fig = tensorboard_utils.show_duration_dists(
+            #         fig_size=(15, rho.shape[0] * 2), rho=rho
+            #     )
+            #     fig_numpy_array = tensorboard_utils.plot_to_image(matplotlib_fig)
+            #     summary.add_image("Duration", fig_numpy_array, step, dataformats="HWC")
+
+            # if step == config["num_steps"]:
+            #     # Evaluate Forecast
+            #     agg_metrics = evaluate_gts_dataset(
+            #         test_dataset,
+            #         model,
+            #         device=device,
+            #         num_samples=config["forecast"]["num_samples"],
+            #         deterministic_z=config["forecast"]["deterministic_z"],
+            #         deterministic_x=config["forecast"]["deterministic_x"],
+            #         deterministic_y=config["forecast"]["deterministic_y"],
+            #         max_len=np.inf,
+            #         batch_size=100,
+            #     )
+            #     summary_items["metrics/test_mse"] = agg_metrics["MSE"]
+            #     summary_items["metrics/CRPS"] = agg_metrics["mean_wQuantileLoss"]
+            #     all_metrics["step"].append(step)
+            #     all_metrics["CRPS"].append(agg_metrics["mean_wQuantileLoss"])
+            #     all_metrics["MSE"].append(agg_metrics["MSE"])
+
+    # Get the preset 78 examples test set examples with hardcoded start/stop indices.    
+    test_dataset__list = make_basketball_dataset_test__as_list() 
+
+    # setup format for return value
+    E = 78
+    J = 10 
+    D = 2 
+    S = config["forecast"]["num_samples"]
+    T_pred =config["prediction_length"]
+    test_forecasts = np.zeros((E, S, T_pred, J, D ))
+    for e, test_example in enumerate(test_dataset__list):
+        test_example = test_example.to(device)
+
+        result_dict = model.predict(
+                test_example.to(device),
+                num_samples=config["forecast"]["num_samples"],
+                basketball=True,
+        )
+        # Rk: I don't think we have any use for result_dict["z_emp_probs"]?
+        #       This seems to be the z probs in the forecast range.
+
+        # here we reshape the array.  in the return value
+        # one example has dimension (S, batch_dim=1, T_pred, JXD).
+        # as implied by the init above, we want the whole thing to be (E, S, T_pred, J, D ).
+        test_forecasts[e] =result_dict["forecast"][:,0].reshape(S,  T_pred, J,D )
+ 
+    
+    breakpoint()
+    # Here I can compare the forecasts to the reality (might need to train longer)
+
+
+        # np.shape(result_dict["rec_n_forecast"]) = (20,1,30,20)
+        # this seems to be for one example we have (S, discard, T_forecast, JXD)
+
+        # complete_ts = val_batch["past_target"][0:1]
+        # matplotlib_fig = tensorboard_utils.show_time_series_forecast(
+        #     fig_size=(12, 4),
+        #     inputs=complete_ts.data.cpu().numpy()[0],
+        #     rec_with_forecast=rec_with_forecast,
+        #     context_length=config["context_length"],
+        #     prediction_length=config["prediction_length"],
+        #     fig_title="forecast",
+        # )
+        # fig_numpy_array = tensorboard_utils.plot_to_image(matplotlib_fig)
+        # summary.add_image("Forecast", fig_numpy_array, step, dataformats="HWC")
+
+        # for k, v in summary_items.items():
+        #     summary.add_scalar(k, v, step)
+        # summary.flush()
+
+    # with open(os.path.join(config["log_dir"], "metrics.json"), "w") as fp:
+    #     json.dump(all_metrics, fp)

--- a/run_basketball.py
+++ b/run_basketball.py
@@ -215,7 +215,7 @@ if __name__ == "__main__":
                 np.save(loss_history_path, loss_history)
             
                 # Make plot of loss and save to disk.
-                plt.plot(loss_history-min(loss_history))
+                plt.plot((loss_history-min(loss_history))[:step])
                 plt.yscale('log')  # log scale for y-axis
                 plt.xlabel("Step")
                 plt.ylabel("Log (loss - min loss)")

--- a/run_segmentation.py
+++ b/run_segmentation.py
@@ -26,7 +26,9 @@ from src.model_utils import build_model
 from src.evaluation import evaluate_segmentation
 from src.torch_utils import torch2numpy
 
-available_datasets = {"bouncing_ball", "3modesystem", "bee"}
+from src.basketball.dataset import make_basketball_dataset
+
+available_datasets = {"bouncing_ball", "3modesystem", "bee", "basketball"}
 
 
 def train_step(batch, model, optimizer, step, config):
@@ -135,6 +137,11 @@ def get_dataset(dataset):
     elif dataset == "bee":
         train_dataset = datasets.BeeDataset(path="./data/bee.npz")
         test_dataset = datasets.BeeDataset(path="./data/bee_test.npz")
+    elif dataset == "basketball":
+        # TODO: Add other training lengths besides one game
+        # TODO: make traj_length a parameter
+        train_dataset = make_basketball_dataset(data_type="train_1", traj_length=15) 
+        test_dataset = make_basketball_dataset(data_type="test", traj_length=15) 
     return train_dataset, test_dataset
 
 
@@ -152,7 +159,17 @@ if __name__ == "__main__":
         default="cpu",
         help="Which device to use, e.g., cpu, cuda:0, cuda:1, ...",
     )
-    args = parser.parse_args()
+    
+    # Actual CLI input
+    # args = parser.parse_args()
+
+    # Simulate CLI input
+    args = parser.parse_args(["--config", "configs/basketball.yaml", "--device", "cpu"])
+    #args = parser.parse_args(["--config", "configs/bee_duration.yaml", "--device", "cpu"])
+
+
+    # Inspect
+    print(args)
 
     # CONFIG
     if args.ckpt:
@@ -166,7 +183,8 @@ if __name__ == "__main__":
 
     # DATA
     train_dataset, test_dataset = get_dataset(config["dataset"])
-    num_workers = 0 if config["dataset"] == "bee" else 4
+    # TODO: check if we can run basketball with more workers.
+    num_workers = 0 if (config["dataset"] == "bee" or config["dataset"] == "basketball") else 4
     train_loader = torch.utils.data.DataLoader(
         train_dataset,
         batch_size=config["batch_size"],

--- a/src/basketball/dataset.py
+++ b/src/basketball/dataset.py
@@ -41,7 +41,6 @@ class Basketball_Dataset_Train(Dataset):
         court_dims = 2
         total_dim =  num_players * court_dims 
         traj = torch.zeros((self.traj_length, total_dim))
-        
         ### make item by finding timestep interval that doesn't overlap with example boundaries
         next_example_stop_idx, t_end = -np.inf, np.inf
         while next_example_stop_idx < t_end:

--- a/src/basketball/dataset.py
+++ b/src/basketball/dataset.py
@@ -1,0 +1,142 @@
+
+import os
+import re
+import numpy as np
+import random 
+
+from typing import List 
+
+import torch
+from torch.utils.data import Dataset, DataLoader
+
+class Basketball_Dataset_Train(Dataset):
+    """
+    Create a dataset which has __getitem__ defined to give a batch in the form expected by RED-SDS
+
+    1) Their model trains on minibatches. 
+    2) Their model requires a different data representation:
+        torch tensors rather than numpy arrays with permuted dimensions
+    3) ...etc.
+    
+    However, we deliver data in a way that matches experiments for the HSRDM paper:
+
+    1) We feed their model minibatches that never straddle an example boundary.
+    """
+    def __init__(self, coords, example_stop_idxs, traj_length):
+        self.coords = coords
+        self.example_stop_idxs = example_stop_idxs
+        self.traj_length = traj_length
+
+    def __len__(self):
+        return len(self.coords)
+
+    def __getitem__(self, index):
+        """
+        Returns:
+            traj, torch.Tensor with shape 
+                (traj_length, num_players * court_dims=20)
+        """
+        T = len(self.coords)
+        num_players  = 10
+        court_dims = 2
+        total_dim =  num_players * court_dims 
+        traj = torch.zeros((self.traj_length, total_dim))
+        
+        ### make item by finding timestep interval that doesn't overlap with example boundaries
+        next_example_stop_idx, t_end = -np.inf, np.inf
+        while next_example_stop_idx < t_end:
+            t_start = random.randint(0, T - self.traj_length)
+            next_example_stop_idx = next((item for item in self.example_stop_idxs if item > t_start), None)
+            t_end = t_start + self.traj_length
+
+        coords = self.coords[t_start:t_start + self.traj_length]
+        # "flatten" 10 players x 2 court dims into 20 dims
+        # player 0's (x,y), player 1's (x,y), etc.
+        traj =  torch.Tensor(coords).reshape(self.traj_length, total_dim) 
+        return traj
+
+
+DATA_DIR = "data/basketball/baller2vec_format/processed/"
+
+def make_basketball_dataset_train(
+    data_type : str, traj_length: int,
+) -> Basketball_Dataset_Train:
+    
+    """
+    Arguments:
+        data_type: str, in ["train_1", "train_5", "train_20"]
+    """
+
+    if data_type == "train_1":
+        coords_filepath = os.path.join(DATA_DIR, "player_coords_train__with_1_games.npy")
+        example_stop_idxs_filepath = os.path.join(DATA_DIR, "example_stop_idxs_train__with_1_games.npy")
+    elif data_type == "train_5":
+        coords_filepath = os.path.join(DATA_DIR, "player_coords_train__with_5_games.npy")
+        example_stop_idxs_filepath = os.path.join(DATA_DIR, "example_stop_idxs_train__with_5_games.npy")
+    elif data_type == "train_20":
+        coords_filepath = os.path.join(DATA_DIR, "player_coords_train__with_20_games.npy")
+        example_stop_idxs_filepath = os.path.join(DATA_DIR, "example_stop_idxs_train__with_20_games.npy")
+    else: 
+        raise ValueError(f"I don't understand data_type {data_type}, which should tell me whether to train or test"
+                         f"and also the training size.  See function docstring.")  
+
+    coords = np.load(coords_filepath)
+    example_stop_idxs = np.load(example_stop_idxs_filepath)
+
+    # Create a dataset which has __getitem__ defined to give a batch in the form expected by GroupNet
+    return Basketball_Dataset_Train(coords, example_stop_idxs, traj_length)
+
+
+def get_basketball_test_start_and_stop_idxs():
+
+    # TODO: Make this not hardcoded... get it from somewhere else.
+    root_dir="/Users/miw267/Repos/team-dynamics-time-series/results/basketball/CLE_starters/artifacts/rebuttal_L=5_K=10_model_type_Linear_And_Out_Of_Bounds_Entity_Recurrence__and__All_Player_Locations_System_Recurrence_train_1_CAVI_its_20_timestamp__12-04-2023_21h10m50s_forecasts_random_forecast_starting_points_True_T_forecast_30/"
+    subdirs = [name for name in os.listdir(root_dir)
+            if os.path.isdir(os.path.join(root_dir, name))]
+
+
+    # Regular expression to extract start and stop idx
+    pattern = re.compile(r"start_idx_(\d+)_stop_idx_(\d+)")
+
+    start_idxs=[]
+    stop_idxs=[]
+    for d in subdirs:
+        match = pattern.search(d)
+        if match:
+            start_idx, stop_idx = map(int, match.groups())
+            start_idxs.append(start_idx)
+            stop_idxs.append(stop_idx)
+        else:
+            raise ValueError
+
+    return start_idxs, stop_idxs
+
+def make_basketball_dataset_test__as_list() -> List[torch.Tensor]:    
+    """
+    Returns:
+        List of 78 examples.  Each list element is an torch Tensor of shape
+            (T_e, J*D),
+        where 
+            T_e is the number of timesteps in that example, 
+            J is the number of players,
+            D is the court dimension (2)
+    """
+    coords_filepath = os.path.join(DATA_DIR, "player_coords_test__with_5_games.npy")
+    example_stop_idxs_filepath = os.path.join(DATA_DIR, "example_stop_idxs_test__with_5_games.npy")
+    coords = np.load(coords_filepath)
+    example_stop_idxs = np.load(example_stop_idxs_filepath)
+
+    start_idxs, stop_idxs = get_basketball_test_start_and_stop_idxs()
+    if not (len(start_idxs)==len(stop_idxs)==78):
+        raise ValueError("There should be 78 examples in the test set.")
+
+    num_players, court_dims = 10, 2
+    total_dim =  num_players * court_dims 
+
+    test_set_list = [None]*78
+    for e in range(78):
+        start_idx, stop_idx = start_idxs[e], stop_idxs[e]
+        T_example = stop_idx-start_idx
+        # we use 1 for the batch dimension, to be consistent with the rest of the code.
+        test_set_list[e]=torch.Tensor(coords[start_idx:stop_idx]).reshape(1,T_example, total_dim)
+    return test_set_list

--- a/src/basketball/examples.py
+++ b/src/basketball/examples.py
@@ -1,0 +1,43 @@
+from typing import Tuple
+import numpy as np 
+
+"""
+This module copypasta'd from (my fork of) GroupNet repo.
+"""
+
+###
+# Types
+###
+
+NumpyArray1D = np.array 
+
+###
+# Helper Functions
+###
+
+### The two functions below are used to convert `example_end_times` into pairs
+### of indices designating the beginning and end of an event.
+
+
+def get_start_and_stop_timestep_idxs_from_event_idx__using_one_indexing(
+    event_stop_idxs: NumpyArray1D, event_idx_in_one_indexing: int
+) -> Tuple[int]:
+    """
+    Arguments:
+        event_stop_idxs: whose usage is very well documented in `run_CAVI_with_JAX`
+    """
+    start_idx = event_stop_idxs[(event_idx_in_one_indexing - 1)] + 1
+    stop_idx = event_stop_idxs[event_idx_in_one_indexing]
+    return (start_idx, stop_idx)
+
+
+def get_start_and_stop_timestep_idxs_from_event_idx(
+    event_stop_idxs: NumpyArray1D, event_idx_in_zero_indexing: int
+) -> Tuple[int]:
+    """
+    Arguments:
+        event_stop_idxs: whose usage is very well documented in `run_CAVI_with_JAX`
+    """
+    return get_start_and_stop_timestep_idxs_from_event_idx__using_one_indexing(
+        event_stop_idxs, event_idx_in_zero_indexing + 1
+    )

--- a/src/basketball/stack_forecasts.py
+++ b/src/basketball/stack_forecasts.py
@@ -16,8 +16,7 @@ Goal:
         (E,S,T_pred,J,D) = (78,20,30,10,2)
 """
 
-forecasts_dir="results/basketball/basketball_post_multivariate_forecasting_bug_fix/forecasts/"
-#forecasts_dir="results/basketball/2025_05_05_174256/forecasts/"
+forecasts_dir="results/basketball/2025_05_06_111833/forecasts"
 
 
 for n_train in [1,5,20]:
@@ -26,11 +25,11 @@ for n_train in [1,5,20]:
     forecasts_test=np.zeros((E,S,T_pred,J,D))
 
     for j in range(10):
-        basename=f"forecasts_test__SNLDS__n_train_{n_train}__step_30000__player_{j}.npy"
+        basename=f"forecasts_test__SNLDS__n_train_{n_train}__step_20000__player_{j}.npy"
         path=os.path.join(forecasts_dir,basename)
         forecasts_test_for_player_j=np.load(path) # shape (78, 20, 30, 1, 2)
         forecasts_test[:,:,:,j,:]=forecasts_test_for_player_j[:,:,:,0,:]
 
-    basename_stacked=f"forecasts_test__SNLDS__n_train_{n_train}__step_30000_all_players_individ_strat.npy"
+    basename_stacked=f"forecasts_test__SNLDS__n_train_{n_train}__step_20000_all_players_individ_strat.npy"
     save_path_stacked=os.path.join(forecasts_dir,basename_stacked)
     np.save(save_path_stacked,forecasts_test)

--- a/src/basketball/stack_forecasts.py
+++ b/src/basketball/stack_forecasts.py
@@ -16,7 +16,9 @@ Goal:
         (E,S,T_pred,J,D) = (78,20,30,10,2)
 """
 
-forecasts_dir="results/basketball/2025_04_29_182232/forecasts/"
+forecasts_dir="results/basketball/basketball_post_multivariate_forecasting_bug_fix/forecasts/"
+#forecasts_dir="results/basketball/2025_05_05_174256/forecasts/"
+
 
 for n_train in [1,5,20]:
 

--- a/src/basketball/stack_forecasts.py
+++ b/src/basketball/stack_forecasts.py
@@ -1,0 +1,34 @@
+import os
+
+import numpy as np 
+
+
+"""
+Goal: 
+    When using the INDEPENDENT TRAINING strategy 
+    (n_players=1, which gives one model for each of 10 players),
+    we obtain one .npy file with forecasts for each of 10 players.
+    
+    Each one has shape  
+        (E,S,T_pred,J_single,D) = (78,20,30,1,2)
+    
+    We want to "stack" these 10 forecast files into a single forecast file with shape
+        (E,S,T_pred,J,D) = (78,20,30,10,2)
+"""
+
+forecasts_dir="results/basketball/2025_04_29_182232/forecasts/"
+
+for n_train in [1,5,20]:
+
+    E,S,T_pred,J,D = 78,20,30,10,2
+    forecasts_test=np.zeros((E,S,T_pred,J,D))
+
+    for j in range(10):
+        basename=f"forecasts_test__SNLDS__n_train_{n_train}__step_30000__player_{j}.npy"
+        path=os.path.join(forecasts_dir,basename)
+        forecasts_test_for_player_j=np.load(path) # shape (78, 20, 30, 1, 2)
+        forecasts_test[:,:,:,j,:]=forecasts_test_for_player_j[:,:,:,0,:]
+
+    basename_stacked=f"forecasts_test__SNLDS__n_train_{n_train}__step_30000_all_players_individ_strat.npy"
+    save_path_stacked=os.path.join(forecasts_dir,basename_stacked)
+    np.save(save_path_stacked,forecasts_test)

--- a/src/model.py
+++ b/src/model.py
@@ -631,7 +631,7 @@ class SNLDS(Base):
         if self.transform_target:
             with torch.no_grad():
                 rec_y_with_forecast = target_transformer(rec_y_with_forecast)
-        return dict(forecast=forecast, z_emp_probs=z_emp_probs)
+        return dict(forecast=forecast, z_emp_probs=z_emp_probs, rec_y_with_forecast=rec_y_with_forecast)
 
 
 class REDSDS(Base):

--- a/src/model.py
+++ b/src/model.py
@@ -326,6 +326,7 @@ class SNLDS(Base):
         cont_ent_anneal: float = 1.0,
         num_samples: int = 1,
         deterministic_inference: bool = False,
+        force_breakpoint: bool = False,
     ):
         y = y[:, : self.context_length, :]
         eps = get_precision(y)
@@ -419,6 +420,10 @@ class SNLDS(Base):
         )
         #  Reconstruct the observations for visualization.
         recons_y = self.get_reconstruction(x_samples).view([num_samples, B, T, -1])
+        if force_breakpoint:
+            print("forcing breakpoint")
+            breakpoint()
+            
         #   Compute the KL between the discrete prior and gamma.
         crossent_regularizer = (
             torch.einsum("ijk, k -> ij", log_gamma, self.discrete_prior).sum(1).mean(0)
@@ -517,10 +522,11 @@ class SNLDS(Base):
             num_samples = 1
         self.eval()
         if basketball:
-            y=y[..., :-self.prediction_length:, :]
+            y=y[..., -self.prediction_length:, :]
         else:
             y = y[..., : self.context_length, :]
         eps = get_precision(y)
+
         # Scale and shift input
         if self.transform_target:
             with torch.no_grad():
@@ -755,6 +761,7 @@ class REDSDS(Base):
         cont_ent_anneal: float = 1.0,
         num_samples: int = 1,
         deterministic_inference: bool = False,
+        force_breakpoint: bool = False,
     ):
         y = y[:, : self.context_length, :]
         eps = get_precision(y)
@@ -861,6 +868,9 @@ class REDSDS(Base):
         )
         #  Reconstruct the observations for visualization.
         recons_y = self.get_reconstruction(x_samples).view([num_samples, B, T, -1])
+        if force_breakpoint:
+            print("forcing breakpoint")
+            breakpoint()
         #   Compute the KL between the discrete prior and gamma.
         crossent_regularizer = (
             torch.einsum("ijk, k -> ij", log_z_posterior, self.discrete_prior)
@@ -984,7 +994,7 @@ class REDSDS(Base):
             num_samples = 1
         self.eval()
         if basketball:
-            y=y[..., :-self.prediction_length:, :]
+            y=y[..., -self.prediction_length:, :]
         else:
             y = y[..., : self.context_length, :]
         eps = get_precision(y)

--- a/src/model.py
+++ b/src/model.py
@@ -517,12 +517,15 @@ class SNLDS(Base):
         deterministic_y: bool = False,
         mean_prediction: bool = False,
         basketball: bool = True, 
+        y_is_already_restricted_to_context_set: bool = False, 
     ):
         if mean_prediction:
             num_samples = 1
         self.eval()
-        if basketball:
+        if basketball and not y_is_already_restricted_to_context_set:
             y=y[..., :-self.prediction_length, :]
+        elif basketball and y_is_already_restricted_to_context_set:
+            y=y
         else:
             y = y[..., : self.context_length, :]
         eps = get_precision(y)

--- a/src/model.py
+++ b/src/model.py
@@ -522,7 +522,7 @@ class SNLDS(Base):
             num_samples = 1
         self.eval()
         if basketball:
-            y=y[..., -self.prediction_length:, :]
+            y=y[..., :-self.prediction_length, :]
         else:
             y = y[..., : self.context_length, :]
         eps = get_precision(y)

--- a/src/model_utils.py
+++ b/src/model_utils.py
@@ -177,6 +177,7 @@ def get_network_instances(config):
         or config["experiment"] == "3modesystem"
         or config["experiment"] == "bee"
         or config["experiment"] == "gts_univariate"
+        or config["experiment"] == "basketball"
     ):
         # Inference Network
         inf_ctrl_dim = (

--- a/src/subnetworks.py
+++ b/src/subnetworks.py
@@ -183,7 +183,7 @@ class InitialContinuousDistribution(nn.Module):
         sigma=None,
         takes_ctrl=False,
         max_scale=1.0,
-        scale_nonlinearity="softplus",
+        scale_nonlinearity="sigmoid",
     ):
         super().__init__()
         assert (
@@ -252,7 +252,7 @@ class ContinuousStateTransition(nn.Module):
         sigma=None,
         takes_ctrl=False,
         max_scale=1.0,
-        scale_nonlinearity="softplus",
+        scale_nonlinearity="sigmoid",
     ):
         """A torch module that models p(x[t] | x[t-1], z[t]).
 
@@ -425,7 +425,7 @@ class GaussianDistributionOutput(nn.Module):
         use_trainable_cov=True,
         sigma=None,
         max_scale=1.0,
-        scale_nonlinearity="softplus",
+        scale_nonlinearity="sigmoid",
     ):
         """A Gaussian distribution on top of a neural network.
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -131,7 +131,11 @@ def get_config_and_setup_dirs(filename="config.yaml"):
 
     config["log_dir"] = config["log_dir"].format(timestamp=timestamp)
     config["model_dir"] = config["model_dir"].format(timestamp=timestamp)
+    config["forecasts_dir"] = config["forecasts_dir"].format(timestamp=timestamp)
+    config["train_history_dir"] = config["train_history_dir"].format(timestamp=timestamp)
     os.makedirs(config["log_dir"])
     os.makedirs(config["model_dir"])
+    os.makedirs(config["forecasts_dir"])
+    os.makedirs(config["train_history_dir"])
 
     return config


### PR DESCRIPTION
CAVEATS:

These changes haven't been extended yet to RED-SDS. I would need to modify the predict method of that class as I did for the SNLDS class.

The code could be cleaned up a bit.

For example:
a. I originally intended to use the "Concatenation" strategy for handling the system-to-entity conversion (see our group dynamics paper on arxiv, under review at TMLR, to explain this). Basically, I was intending to model all 10 basketball players together. However, the forecasts were junky (discontinuous, and starting in wildly bad places). So I switched to modeling each player independently (the "Independent" strategy), where n_players=1 in the configs. Forecasts were still junky, until eventually I found and fixed a few bugs in my code. (These bugs are described in commits https://github.com/abdulfatir/REDSDS/commit/7fd865c767e862528b41f86bd4247fbd6c405c55 and https://github.com/abdulfatir/REDSDS/commit/cd0648adec54e3215423fa0fd1ab9aa3a3351670). After these changes, the forecasts look reasonable. It's possible that the "Concatenation" strategy would not work swimmingly. However, I haven't tested it yet. Probably the code should be polished so it's not reflecting this path into and out of bugs. Even better, it would ideally be updated to support both strategies. (I think there are a few minor places that unnecessarily force people into assuming the "Independent" strategy.)
b. There are some basic violations of D.R.Y.
c. I am doing debugging with test data structured in one way (namely, without the use of random context times), and forecasting with test data structured in another. This is unnecessary; it should be streamlined. As with a., this structure is an unfortunate byproduct of how the code evolved; I had initially forgotten that we were using random context times in the earlier stages of developing this code.